### PR TITLE
[feat] 정책 카드 컴포넌트 구현(#2)

### DIFF
--- a/app/components/BasicInfoForm.js
+++ b/app/components/BasicInfoForm.js
@@ -15,13 +15,8 @@ export default function BasicInfoForm() {
   const clickSeoulModal = () => setShowSeoulModal((prev) => !prev);
   const clickPolicyModal = () => setShowPolicyModal((prev) => !prev);
 
-  const removePolicy = (policyToRemove) => {
-    setSelectedPolicies((prev) =>
-      prev.filter((policy) => policy !== policyToRemove)
-    );
-  };
   return (
-    <section className="bg-white p-10 rounded-2xl shadow-md max-w-5xl mx-auto mt-6 pb-30">
+    <div>
       <h2 className="text-lg font-semibold text-gray-800 mb-4">
         기본 정보 입력
       </h2>
@@ -112,6 +107,6 @@ export default function BasicInfoForm() {
           검색하기
         </button>
       </form>
-    </section>
+    </div>
   );
 }

--- a/app/components/PolicyCard.js
+++ b/app/components/PolicyCard.js
@@ -1,0 +1,54 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { AiFillHeart, AiOutlineHeart } from "react-icons/ai";
+
+export default function PolicyCard({ policyInfo }) {
+  const [likesState, setLikesState] = useState(policyInfo.likes);
+  const changeLikesState = () => setLikesState(!likesState);
+  return (
+    <div className="bg-white rounded-2xl shadow-md p-5 w-80 relative">
+      {/* 상단 상태 및 아이콘 */}
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2">
+          <span className="text-red-500 text-sm font-semibold">
+            신청마감 D-24
+          </span>
+          <span className="text-gray-500 text-xs border border-gray-300 rounded px-2 py-0.5">
+            {policyInfo.district}
+          </span>
+        </div>
+        {/* Todo: likes 상태 로컬 스토리지에 저장 */}
+        <button onClick={changeLikesState}>
+          {likesState ? (
+            <AiFillHeart className="text-red-500" size={20} />
+          ) : (
+            <AiOutlineHeart className="text-red-500" size={20} />
+          )}
+        </button>
+      </div>
+
+      {/* 제목 */}
+      <h3 className="text-md font-bold mb-1">{policyInfo.name}</h3>
+
+      {/* 지원 내용 */}
+      <p className="text-sm text-gray-700 mb-1">{policyInfo.content}</p>
+
+      {/* 대상 */}
+      <p className="text-sm text-gray-600 mb-1">대상: {policyInfo.target}</p>
+
+      {/* 기간 */}
+      <p className="text-sm text-gray-400 mb-4">
+        신청 기간: {policyInfo.startDate} ~ {policyInfo.endDate}
+      </p>
+
+      {/* 버튼 */}
+      <Link href={`/detail/${policyInfo.index}`}>
+        <button className="w-full py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold rounded-xl">
+          자세히 보기
+        </button>
+      </Link>
+    </div>
+  );
+}

--- a/app/page.js
+++ b/app/page.js
@@ -1,6 +1,41 @@
 import BasicInfoForm from "./components/BasicInfoForm";
+import PolicyCard from "./components/PolicyCard";
 
 export default function Home() {
+  // Todo: 서버에서 가져오기
+  let policies = [
+    {
+      index: 1,
+      likes: false,
+      name: "정책1",
+      district: "광진구",
+      content: "11만원 지원함",
+      target: "만 19세 ~ 만 24세 이하",
+      startDate: "2024-01-01",
+      endDate: "2024-02-02",
+    },
+    {
+      index: 2,
+      likes: false,
+      name: "정책2",
+      district: "용산구",
+      content: "22만원 지원함",
+      target: "만 19세 ~ 만 24세 이하",
+      startDate: "2024-01-01",
+      endDate: "2024-02-02",
+    },
+    {
+      index: 3,
+      likes: false,
+      name: "정책2",
+      district: "종로구",
+      content: "33만원 지원함",
+      target: "만 19세 ~ 만 24세 이하",
+      startDate: "2024-01-01",
+      endDate: "2024-02-02",
+    },
+  ];
+
   return (
     <div>
       <section className="text-center py-8 px-4 bg-gray-50">
@@ -11,7 +46,15 @@ export default function Home() {
           내 조건에 맞는 현재 신청 가능한 정책을 찾아보세요
         </p>
       </section>
-      <BasicInfoForm />
+      <section className="bg-white p-10 rounded-2xl shadow-md max-w-5xl mx-auto mt-6 pb-30">
+        <BasicInfoForm />
+
+        <div className="flex pt-50 gap-10">
+          {policies.map((policy, i) => {
+            return <PolicyCard policyInfo={policy} key={i} />;
+          })}
+        </div>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
- 정책은 가로 3개씩 정렬된 카드로 표시
- 각 카드에는 다음 정보 포함:
  - [x] 신청 마감 기한
  - [x] 찜 여부
  - [x] 정책명
  - [x] 자치구
  - [x] 지원 내용
  - [x] 지원 대상
  - [x] 신청 기간